### PR TITLE
Reduce the recalculate style with pure CSS

### DIFF
--- a/notes/src/components/NoteButton/index.css
+++ b/notes/src/components/NoteButton/index.css
@@ -48,13 +48,10 @@
   display: block;
   white-space: nowrap;
   overflow: hidden;
-}
-
-.notes-list__note-header_overflowing {
   position: relative;
 }
 
-.notes-list__note-header_overflowing::after {
+.notes-list__note-header::after {
   content: "";
   position: absolute;
   right: 0;

--- a/notes/src/components/NoteButton/index.jsx
+++ b/notes/src/components/NoteButton/index.jsx
@@ -2,23 +2,9 @@ import ReactMarkdown from "react-markdown";
 import gfm from "remark-gfm";
 import { format } from "date-fns";
 import "./index.css";
-import { memo, useLayoutEffect, useRef } from "react";
+import { memo } from "react";
 
 function NoteButton({ isActive, onNoteActivated, id, text, filterText, date }) {
-  const noteHeader = useRef();
-
-  useLayoutEffect(() => {
-    if (noteHeader.current) {
-      if (noteHeader.current.scrollWidth > noteHeader.current.clientWidth) {
-        noteHeader.current.classList.add("notes-list__note-header_overflowing");
-      } else {
-        noteHeader.current.classList.remove(
-          "notes-list__note-header_overflowing"
-        );
-      }
-    }
-  }, [text]);
-
   const className = [
     "notes-list__button",
     "notes-list__note",
@@ -32,7 +18,7 @@ function NoteButton({ isActive, onNoteActivated, id, text, filterText, date }) {
       <span className="notes-list__note-meta">
         {format(date, "d MMM yyyy")}
       </span>
-      <span className="notes-list__note-header" ref={noteHeader}>
+      <span className="notes-list__note-header">
         {generateNoteHeader(text, filterText)}
       </span>
     </button>
@@ -58,8 +44,8 @@ function generateNoteHeader(text, filterText) {
     const firstLineParts = firstLine.split(
       new RegExp(
         "(" + filterText.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&") + ")",
-        "gi"
-      )
+        "gi",
+      ),
     );
 
     // This wraps all `filterText` entries with a `del` tag.


### PR DESCRIPTION
## In this Pull Request

Reduce the **[recalculating style](https://web.dev/articles/reduce-the-scope-and-complexity-of-style-calculations)** in the [NoteButton](https://github.com/nucliweb/react-workshop-fwdays-mar24/tree/day3/notes/src/components/NoteButton) component to improve the [Interaction to Next Paint](https://web.dev/articles/inp)

## Interaction: original vs fix

| Before | After |
| ------ | ----- |
| ![image](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/2858742d-27c8-4970-8707-231836d3e295) | ![image](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/cdd4ad15-9ba4-45ca-a105-d72a2d53a75f) |

## Recalculate style (purple): original vs fix

### Before
![main](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/7146ecec-0c05-4e6f-b75d-57e2f342f65c)

### After
![fix](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/4de37afb-c8e5-4dc8-911f-798736e8c0b4)

## Why?

The original code uses a **useLayoutEffect** hook to add or remove a CSS class.

The CSS class adds the property `position: relative;` and a pseudo-element to render a gradient effect as an alternative to the `position: relative;`

```js
  useLayoutEffect(() => {
    if (noteHeader.current) {
      if (noteHeader.current.scrollWidth > noteHeader.current.clientWidth) {
        noteHeader.current.classList.add("notes-list__note-header_overflowing");
      } else {
        noteHeader.current.classList.remove(
          "notes-list__note-header_overflowing"
        );
      }
    }
  }, [text]);
```

## Take a look at the CSS

The main class `notes-list__note-header` of the `<span>` element has a `display: block`, so the element uses the width 100% of the parent element.

This means we can move the pseudo-element to the main class since it will be rendered to the element's right.

<img width="563" alt="image" src="https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/3ef43f1e-1500-4499-a3d1-15722258ae62">


### Here we have an example of the three scenarios:

1. Short text (really, we don't need the pseudo-element)
2. Long text and selected button
3. Long text and unselected button

It works fine because we are using a custom property, and use the background color.

```css
.notes-list__note-header_overflowing::after {
  content: "";
  position: absolute;
  right: 0;
  top: 0;
  bottom: 0;
  width: 20px;
  background: linear-gradient(to right, transparent, var(--note-background)); 👈
  z-index: 1;
}
```

## Screenshots

### Before

![Screenshot 2024-03-16 at 13 23 08](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/680a0418-c304-4b5e-85a9-63a303cde0b4)

### After

![Screenshot 2024-03-16 at 13 27 06](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/d450e0e2-0678-4054-88bf-bee5435125c6)


## Trace profile

- [Original version on trace.cafe](https://trace.cafe/t/7kWy3GJTr9)
- [Fixed version on trace.cafe](https://trace.cafe/t/cFnYul6NZH)
- [JSON files on Issue #3](https://github.com/nucliweb/react-workshop-fwdays-mar24/issues/3)
