### PR TITLE
Add content-visibility to NoteButton component

### DIFF
--- a/notes/src/components/NoteButton/index.css
+++ b/notes/src/components/NoteButton/index.css
@@ -24,6 +24,8 @@
   padding: 6px 12px;
   background: var(--note-background);
   border-radius: 4px;
+  content-visibility: auto;
+  contain-intrinsic-size: 50px auto;
 }
 
 .notes-list__note:hover {


### PR DESCRIPTION
## Add content-visibility to the `NoteButton` component

Add `content-visibility` CSS property to improve the rendering layout

## Layout

### Before

![Layout-Origin](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/4d54c8fb-4f76-417f-8153-d43351671f5c)


### After

![Layout-Fix](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/0edacbba-6505-4e78-bdc7-44a364660ef1)

## Layers

### Before

![Layers-Origin](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/c997feb0-35d9-4548-a60a-d4a2e0a59ca6)

### After

![Layers-Fix](https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/98ba04d0-172c-4d53-a5e3-a6ffa842effb)

### Video


https://github.com/nucliweb/react-workshop-fwdays-mar24/assets/1307927/c5861043-fb2e-4acf-9962-4d726a89fef0

